### PR TITLE
Upgrade GraphiQL to version 0.8.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ scalaVersion := "2.11.8"
 scalacOptions ++= Seq("-deprecation", "-feature")
 
 libraryDependencies ++= Seq(
-  "org.sangria-graphql" %% "sangria" % "1.0.0-RC2",
-  "org.sangria-graphql" %% "sangria-spray-json" % "0.3.1",
+  "org.sangria-graphql" %% "sangria" % "1.0.0-RC3",
+  "org.sangria-graphql" %% "sangria-spray-json" % "0.3.2",
   "com.typesafe.akka" %% "akka-http-experimental" % "2.4.11",
   "com.typesafe.akka" %% "akka-http-spray-json-experimental" % "2.4.11",
 

--- a/src/main/resources/graphiql.html
+++ b/src/main/resources/graphiql.html
@@ -30,7 +30,7 @@
 <html>
   <head>
     <style>
-      html, body {
+      body {
         height: 100%;
         margin: 0;
         width: 100%;
@@ -42,14 +42,16 @@
       }
     </style>
 
-    <link rel="stylesheet" href="//cdn.jsdelivr.net/graphiql/0.7.8/graphiql.css" />
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/graphiql/0.8.0/graphiql.css" />
+    <script src="//cdn.jsdelivr.net/es6-promise/4.0.5/es6-promise.auto.min.js"></script>
     <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
-    <script src="//cdn.jsdelivr.net/react/15.0.1/react.min.js"></script>
-    <script src="//cdn.jsdelivr.net/react/15.0.1/react-dom.min.js"></script>
-    <script src="//cdn.jsdelivr.net/graphiql/0.7.8/graphiql.min.js"></script>
+    <script src="//cdn.jsdelivr.net/react/15.3.2/react.min.js"></script>
+    <script src="//cdn.jsdelivr.net/react/15.3.2/react-dom.min.js"></script>
+    <script src="//cdn.jsdelivr.net/graphiql/0.8.0/graphiql.min.js"></script>
   </head>
   <body>
     <div id="graphiql">Loading...</div>
+
     <script>
 
       /**
@@ -112,7 +114,7 @@
 
       // Defines a GraphQL fetcher using the fetch API.
       function graphQLFetcher(graphQLParams) {
-        return fetch(window.location.origin + "/graphql", {
+        return fetch('/graphql', {
           method: 'post',
           headers: {
             'Accept': 'application/json',

--- a/src/main/scala/Server.scala
+++ b/src/main/scala/Server.scala
@@ -32,7 +32,6 @@ object Server extends App {
 
         val vars = fields.get("variables") match {
           case Some(obj: JsObject) ⇒ obj
-          case Some(JsString(s)) if s.trim.nonEmpty ⇒ s.parseJson
           case _ ⇒ JsObject.empty
         }
 


### PR DESCRIPTION
Allows to remove special handling of string "encoded" variables.
Also bump Sangria deps.