### PR TITLE
Upgraded scala, sbt and libds. Also, extended the example to allow querying for all droids and humans

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,19 +3,19 @@ version := "0.1.0-SNAPSHOT"
 
 description := "An example GraphQL server written with akka-http, circe and sangria."
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.6"
 scalacOptions ++= Seq("-deprecation", "-feature")
 
 libraryDependencies ++= Seq(
   "org.sangria-graphql" %% "sangria" % "1.4.0",
   "org.sangria-graphql" %% "sangria-circe" % "1.2.1",
 
-  "com.typesafe.akka" %% "akka-http" % "10.1.0",
-  "de.heikoseeberger" %% "akka-http-circe" % "1.20.0",
+  "com.typesafe.akka" %% "akka-http" % "10.1.1",
+  "de.heikoseeberger" %% "akka-http-circe" % "1.20.1",
 
-  "io.circe" %%	"circe-core" % "0.9.2",
-  "io.circe" %% "circe-parser" % "0.9.2",
-  "io.circe" %% "circe-optics" % "0.9.2",
+  "io.circe" %%	"circe-core" % "0.9.3",
+  "io.circe" %% "circe-parser" % "0.9.3",
+  "io.circe" %% "circe-optics" % "0.9.3",
 
   "org.scalatest" %% "scalatest" % "3.0.5" % Test
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.1.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
-addSbtPlugin("com.heroku" % "sbt-heroku" % "2.0.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.1")
+addSbtPlugin("com.heroku" % "sbt-heroku" % "2.1.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.4")

--- a/project/sbt-updates.sbt
+++ b/project/sbt-updates.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.4")

--- a/src/main/scala/Data.scala
+++ b/src/main/scala/Data.scala
@@ -32,6 +32,10 @@ class CharacterRepo {
   def getHuman(id: String): Option[Human] = humans.find(c ⇒ c.id == id)
 
   def getDroid(id: String): Option[Droid] = droids.find(c ⇒ c.id == id)
+  
+  def getHumans(): List[Human] = humans
+  
+  def getDroids(): List[Droid] = droids
 }
 
 object CharacterRepo {

--- a/src/main/scala/SchemaDefinition.scala
+++ b/src/main/scala/SchemaDefinition.scala
@@ -110,7 +110,13 @@ object SchemaDefinition {
         resolve = ctx ⇒ ctx.ctx.getHuman(ctx arg ID)),
       Field("droid", Droid,
         arguments = ID :: Nil,
-        resolve = Projector((ctx, f) ⇒ ctx.ctx.getDroid(ctx arg ID).get))
+        resolve = Projector((ctx, f) ⇒ ctx.ctx.getDroid(ctx arg ID).get)),
+      Field("humans", ListType(Human),
+        arguments = Nil,
+        resolve = Projector((ctx, f) ⇒ ctx.ctx.getHumans())),
+      Field("droids", ListType(Droid),
+        arguments = Nil,
+        resolve = Projector((ctx, f) ⇒ ctx.ctx.getDroids()))
     ))
 
   val StarWarsSchema = Schema(Query)


### PR DESCRIPTION
First time I build, I get the following errors:
>[warn] Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[warn]  * org.codehaus.plexus:plexus-utils:3.0.17 is selected over {2.1, 1.5.5}
[warn]      +- org.apache.maven:maven-settings:3.2.2              (depends on 3.0.17)
[warn]      +- org.apache.maven:maven-repository-metadata:3.2.2   (depends on 3.0.17)
[warn]      +- org.apache.maven:maven-aether-provider:3.2.2       (depends on 3.0.17)
[warn]      +- org.apache.maven:maven-model:3.2.2                 (depends on 3.0.17)
[warn]      +- org.apache.maven:maven-core:3.2.2                  (depends on 3.0.17)
[warn]      +- org.apache.maven:maven-artifact:3.2.2              (depends on 3.0.17)
[warn]      +- org.apache.maven:maven-settings-builder:3.2.2      (depends on 3.0.17)
[warn]      +- org.apache.maven:maven-model-builder:3.2.2         (depends on 3.0.17)
[warn]      +- org.sonatype.plexus:plexus-sec-dispatcher:1.3      (depends on 1.5.5)
[warn]      +- org.eclipse.sisu:org.eclipse.sisu.plexus:0.0.0.M5  (depends on 2.1)
[warn]  * com.google.guava:guava:20.0 is selected over {10.0.1, 16.0}
[warn]      +- com.spotify:docker-client:8.9.0                    (depends on 20.0)
[warn]      +- com.fasterxml.jackson.datatype:jackson-datatype-guava:2.8.8 (depends on 16.0)
[warn]      +- org.eclipse.sisu:org.eclipse.sisu.plexus:0.0.0.M5  (depends on 10.0.1)
[warn] Run 'evicted' to see detailed eviction warnings


Seems like one of the build plugins is too old, though I couldn't find which is the trouble maker.