### PR TITLE
🛠  Support Scala 2.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.class
 *.log
 
+# VSCode
+.vscode
+
 # idea
 .idea
 .idea_modules
@@ -11,7 +14,11 @@ target/
 lib_managed/
 src_managed/
 project/boot/
+project/project/
+project/metals.sbt
 project/plugins/project/
 
 # Scala-IDE specific
 .scala_dependencies
+.bloop
+.metals

--- a/build.sbt
+++ b/build.sbt
@@ -3,22 +3,22 @@ version := "0.1.0-SNAPSHOT"
 
 description := "An example GraphQL server written with akka-http, circe and sangria."
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.13.3"
 scalacOptions ++= Seq("-deprecation", "-feature")
 
 libraryDependencies ++= Seq(
-  "org.sangria-graphql" %% "sangria" % "1.4.2",
-  "org.sangria-graphql" %% "sangria-slowlog" % "0.1.8",
-  "org.sangria-graphql" %% "sangria-circe" % "1.2.1",
+  "org.sangria-graphql" %% "sangria" % "2.0.1",
+  "org.sangria-graphql" %% "sangria-slowlog" % "2.0.0-M1",
+  "org.sangria-graphql" %% "sangria-circe" % "1.3.0",
 
-  "com.typesafe.akka" %% "akka-http" % "10.1.3",
-  "de.heikoseeberger" %% "akka-http-circe" % "1.21.0",
+  "com.typesafe.akka" %% "akka-http" % "10.1.8",
+  "de.heikoseeberger" %% "akka-http-circe" % "1.28.0",
 
-  "io.circe" %%	"circe-core" % "0.9.3",
-  "io.circe" %% "circe-parser" % "0.9.3",
-  "io.circe" %% "circe-optics" % "0.9.3",
+  "io.circe" %% "circe-core" % "0.12.3",
+  "io.circe" %% "circe-parser" % "0.12.3",
+  "io.circe" %% "circe-optics" % "0.12.0",
 
-  "org.scalatest" %% "scalatest" % "3.0.5" % Test
+  "org.scalatest" %% "scalatest" % "3.0.8" % Test
 )
 
 Revolver.settings

--- a/src/main/scala/Server.scala
+++ b/src/main/scala/Server.scala
@@ -63,7 +63,7 @@ object Server extends App with CorsSupport {
           explicitlyAccepts(`text/html`) {
             getFromResource("assets/playground.html")
           } ~
-          parameters('query, 'operationName.?, 'variables.?) { (query, operationName, variables) =>
+          parameters(Symbol("query"), Symbol("operationName").?, Symbol("variables").?) { (query, operationName, variables) =>
             QueryParser.parse(query) match {
               case Success(ast) =>
                 variables.map(parse) match {
@@ -76,7 +76,7 @@ object Server extends App with CorsSupport {
           }
         } ~
         post {
-          parameters('query.?, 'operationName.?, 'variables.?) { (queryParam, operationNameParam, variablesParam) =>
+          parameters(Symbol("query").?, Symbol("operationName").?, Symbol("variables").?) { (queryParam, operationNameParam, variablesParam) =>
             entity(as[Json]) { body =>
               val query = queryParam orElse root.query.string.getOption(body)
               val operationName = operationNameParam orElse root.operationName.string.getOption(body)

--- a/src/test/scala/SchemaSpec.scala
+++ b/src/test/scala/SchemaSpec.scala
@@ -36,7 +36,7 @@ class SchemaSpec extends WordSpec with Matchers {
              }
            }
          }
-       """).right.get)
+       """).getOrElse(fail("Failed to parse expected JSON. Please confirm the JSON is valid.")))
     }
 
     "allow to fetch Han Solo using his ID provided through variables" in {
@@ -76,7 +76,7 @@ class SchemaSpec extends WordSpec with Matchers {
              }
            }
          }
-        """).right.get)
+        """).getOrElse(fail("Failed to parse expected JSON. Please confirm the JSON is valid.")))
     }
   }
 


### PR DESCRIPTION
# ✨ Scala 2.13 Support ✨
Updates dependencies to first version of each dependency to support Scala 2.13.

Additionally addresses changes made in Scala 2.13

### Scala changes:
- `'someSymbol` is now `Symbol("someSymbol")`
- `Either` is now Right biased, which means `.right.get` should be moved to `.getOrElse`