### PR TITLE
Creates `prepareGraphQLRequest` and `graphQLPlayground` directives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,12 @@ project/project/
 project/metals.sbt
 project/plugins/project/
 
+.metals/
+.bloop/
+metals.sbt
+
 # Scala-IDE specific
 .scala_dependencies
 .bloop
 .metals
+.vscode/

--- a/src/main/scala/SangriaAkkaHttp.scala
+++ b/src/main/scala/SangriaAkkaHttp.scala
@@ -1,0 +1,136 @@
+
+import akka.http.scaladsl.server.{Route, StandardRoute}
+import akka.http.scaladsl.server.Directives._
+import io.circe.Json
+import io.circe.optics.JsonPath.root
+import io.circe.parser.parse
+import sangria.ast.Document
+import sangria.parser.{QueryParser, SyntaxError}
+import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport.jsonUnmarshaller
+import GraphQLRequestUnmarshaller._
+import akka.http.scaladsl.model.MediaTypes._
+
+import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
+
+case class GraphQLRequest(query: Document, variables: Json, operationName: Option[String])
+object GraphQLRequest {
+    val emptyVariables = Json.obj()
+    def apply(query: Document, variables: Json, operationName: Option[String]): GraphQLRequest =
+      new GraphQLRequest(
+        query = query,
+        variables = if (variables.isNull) emptyVariables else variables,
+        operationName = operationName
+      )
+}
+
+object SangriaAkkaHttp {
+  final case class MalformedRequest(private val message: String = "",
+                                   private val cause: Throwable = None.orNull)
+    extends Exception(message, cause)
+
+  def graphQLPlayground: Route = get {
+    explicitlyAccepts(`text/html`) {
+      getFromResource("assets/playground.html")
+    }
+  }
+
+  def formatError(error: Throwable): Json = error match {
+    case syntaxError: SyntaxError =>
+      Json.obj("errors" -> Json.arr(
+        Json.obj(
+          "message" -> Json.fromString(syntaxError.getMessage),
+          "locations" -> Json.arr(Json.obj(
+            "line" -> Json.fromBigInt(syntaxError.originalError.position.line),
+            "column" -> Json.fromBigInt(syntaxError.originalError.position.column))))))
+    case NonFatal(e) =>
+      formatError(e.getMessage)
+    case e =>
+      throw e
+  }
+
+  def formatError(message: String): Json =
+    Json.obj("errors" -> Json.arr(Json.obj("message" -> Json.fromString(message))))
+
+
+  // This is intended to resolve some duplication of code where `GET` and `POST` requests
+  // mostly function the same way, with some differing source data.
+  def prepareQueryAndVars(maybeQuery: Option[String], maybeVars: Option[String]): Try[(Document, Option[Json])] = {
+    (maybeQuery.map(QueryParser.parse(_)) match {
+      case Some(Success(query)) =>
+        maybeVars.map(parse) match {
+          case Some(Left(error)) => Left(error)
+          case Some(Right(json)) => Right((query, Some(json)))
+          case None => Right((query, None))
+        }
+      case Some(Failure(error)) => Left(error)
+      case None => Left(MalformedRequest(
+        """Could not extract `query` from request.
+          | Please confirm you have included a valid GraphQL
+          |  query either as a QueryString parameter, or in the body of your request.""".stripMargin))
+    }).toTry
+  }
+
+  private def prepareGraphQLPost(inner: Try[GraphQLRequest] => StandardRoute): Route =
+    parameters(Symbol("query").?, Symbol("operationName").?, Symbol("variables").?) { (queryParam, operationNameParam, variablesParam) =>
+        // Content-Type: application/json
+        entity(as[Json]) { body =>
+          val maybeOperationName = operationNameParam orElse root.operationName.string.getOption(body)
+          val maybeQuery = queryParam orElse root.query.string.getOption(body)
+          // Variables may be provided in the QueryString, or possibly in the body as a String.
+          val maybeVariables = variablesParam orElse root.variables.string.getOption(body)
+
+          prepareQueryAndVars(maybeQuery, maybeVariables) match {
+            case Success((document, variablesOpt)) =>
+              val varsFromBody = root.variables.json.getOption(body)
+              // If we were unable to parse the variables from the body as a string,
+              // we read them as JSON, and finally if no variables have been located
+              // in the QueryString, Body (as a String) or Body (as JSON), we provide
+              // an empty JSON object as the final result
+              val finalVars = variablesOpt.orElse(varsFromBody).getOrElse(GraphQLRequest.emptyVariables)
+              val result = GraphQLRequest(
+                query = document,
+                variables = finalVars,
+                operationName = maybeOperationName
+              )
+              inner(Success(result))
+            case Failure(error) => inner(Failure(error))
+          }
+        } ~
+        // Content-Type: application/graphql
+        entity(as[Document]) { document =>
+          variablesParam.map(parse) match {
+            case Some(Left(error)) => inner(Failure(error))
+            case Some(Right(json)) =>
+              val result = GraphQLRequest(query = document, variables = json, operationName = operationNameParam)
+              inner(Success(result))
+            case None =>
+              val result = GraphQLRequest(query = document, variables = GraphQLRequest.emptyVariables, operationName = operationNameParam)
+              inner(Success(result))
+          }
+        }
+
+    }
+
+  private def prepareGraphQLGet(inner: Try[GraphQLRequest] => StandardRoute): Route =
+    parameters(Symbol("query").?, Symbol("operationName").?, Symbol("variables").?) { (maybeQuery, maybeOperationName, maybeVariables) =>
+      prepareQueryAndVars(maybeQuery, maybeVariables) match {
+        case Success((document, variablesOpt)) =>
+          val finalVars = variablesOpt.getOrElse(GraphQLRequest.emptyVariables)
+          val result = GraphQLRequest(
+            query = document,
+            variables = finalVars,
+            maybeOperationName
+          )
+          inner(Success(result))
+        case Failure(error) => inner(Failure(error))
+      }
+  }
+
+  def prepareGraphQLRequest(inner: PartialFunction[Try[GraphQLRequest], StandardRoute]): Route = 
+    get {
+      prepareGraphQLGet{ inner }
+    } ~ post {
+      prepareGraphQLPost{ inner }
+    }
+}

--- a/src/main/scala/Server.scala
+++ b/src/main/scala/Server.scala
@@ -1,104 +1,50 @@
-import sangria.ast.Document
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
 import sangria.execution.deferred.DeferredResolver
 import sangria.execution.{ErrorWithResolver, Executor, QueryAnalysisError}
-import sangria.parser.{QueryParser, SyntaxError}
-import sangria.parser.DeliveryScheme.Try
-import sangria.marshalling.circe._
+import sangria.slowlog.SlowLog
+
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.model.MediaTypes._
 import akka.http.scaladsl.server._
-import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
-import io.circe._
-import io.circe.optics.JsonPath._
-import io.circe.parser._
 
-import scala.util.control.NonFatal
-import scala.util.{Failure, Success}
-import GraphQLRequestUnmarshaller._
-import sangria.slowlog.SlowLog
+import io.circe.Json
+import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport.jsonMarshaller
+import sangria.marshalling.circe._
+
+import SangriaAkkaHttp._
 
 object Server extends App with CorsSupport {
   implicit val system = ActorSystem("sangria-server")
 
   import system.dispatcher
 
-  def executeGraphQL(query: Document, operationName: Option[String], variables: Json, tracing: Boolean) =
-    complete(Executor.execute(SchemaDefinition.StarWarsSchema, query, new CharacterRepo,
-      variables = if (variables.isNull) Json.obj() else variables,
-      operationName = operationName,
-      middleware = if (tracing) SlowLog.apolloTracing :: Nil else Nil,
-      deferredResolver = DeferredResolver.fetchers(SchemaDefinition.characters))
-        .map(OK -> _)
-        .recover {
-          case error: QueryAnalysisError => BadRequest -> error.resolveError
-          case error: ErrorWithResolver => InternalServerError -> error.resolveError
-        })
-
-  def formatError(error: Throwable): Json = error match {
-    case syntaxError: SyntaxError =>
-      Json.obj("errors" -> Json.arr(
-      Json.obj(
-        "message" -> Json.fromString(syntaxError.getMessage),
-        "locations" -> Json.arr(Json.obj(
-          "line" -> Json.fromBigInt(syntaxError.originalError.position.line),
-          "column" -> Json.fromBigInt(syntaxError.originalError.position.column))))))
-    case NonFatal(e) =>
-      formatError(e.getMessage)
-    case e =>
-      throw e
-  }
-
-  def formatError(message: String): Json =
-    Json.obj("errors" -> Json.arr(Json.obj("message" -> Json.fromString(message))))
-
   val route: Route =
     optionalHeaderValueByName("X-Apollo-Tracing") { tracing =>
       path("graphql") {
-        get {
-          explicitlyAccepts(`text/html`) {
-            getFromResource("assets/playground.html")
-          } ~
-          parameters(Symbol("query"), Symbol("operationName").?, Symbol("variables").?) { (query, operationName, variables) =>
-            QueryParser.parse(query) match {
-              case Success(ast) =>
-                variables.map(parse) match {
-                  case Some(Left(error)) => complete(BadRequest, formatError(error))
-                  case Some(Right(json)) => executeGraphQL(ast, operationName, json, tracing.isDefined)
-                  case None => executeGraphQL(ast, operationName, Json.obj(), tracing.isDefined)
-                }
-              case Failure(error) => complete(BadRequest, formatError(error))
-            }
-          }
-        } ~
-        post {
-          parameters(Symbol("query").?, Symbol("operationName").?, Symbol("variables").?) { (queryParam, operationNameParam, variablesParam) =>
-            entity(as[Json]) { body =>
-              val query = queryParam orElse root.query.string.getOption(body)
-              val operationName = operationNameParam orElse root.operationName.string.getOption(body)
-              val variablesStr = variablesParam orElse root.variables.string.getOption(body)
-
-              query.map(QueryParser.parse(_)) match {
-                case Some(Success(ast)) =>
-                  variablesStr.map(parse) match {
-                    case Some(Left(error)) => complete(BadRequest, formatError(error))
-                    case Some(Right(json)) => executeGraphQL(ast, operationName, json, tracing.isDefined)
-                    case None => executeGraphQL(ast, operationName, root.variables.json.getOption(body) getOrElse Json.obj(), tracing.isDefined)
-                  }
-                case Some(Failure(error)) => complete(BadRequest, formatError(error))
-                case None => complete(BadRequest, formatError("No query to execute"))
-              }
-            } ~
-            entity(as[Document]) { document =>
-              variablesParam.map(parse) match {
-                case Some(Left(error)) => complete(BadRequest, formatError(error))
-                case Some(Right(json)) => executeGraphQL(document, operationNameParam, json, tracing.isDefined)
-                case None => executeGraphQL(document, operationNameParam, Json.obj(), tracing.isDefined)
-              }
-            }
-          }
+        graphQLPlayground ~
+        prepareGraphQLRequest {
+          case Success(GraphQLRequest(query, variables, operationName)) =>
+            val middleware = if (tracing.isDefined) SlowLog.apolloTracing :: Nil else Nil
+            val deferredResolver = DeferredResolver.fetchers(SchemaDefinition.characters)
+            val graphQLResponse = Executor.execute(
+                schema = SchemaDefinition.StarWarsSchema,
+                queryAst = query,
+                userContext = new CharacterRepo,
+                variables = variables,
+                operationName = operationName,
+                middleware = middleware,
+                deferredResolver = deferredResolver
+              ).map(OK -> _)
+               .recover {
+                 case error: QueryAnalysisError => BadRequest -> error.resolveError
+                 case error: ErrorWithResolver => InternalServerError -> error.resolveError
+               }
+            complete(graphQLResponse)
+          case Failure(preparationError) => complete(BadRequest, formatError(preparationError))
         }
       }
     } ~


### PR DESCRIPTION
In an effort to help focus on `Sangria`, I have factored out the `akka-http` handling into a directive that can be mounted at any path that is responsible for parsing `GET` and `POST` requests into a `GraphQLRequest` which is simply a data structure to hold a parsed Query AST, Variables, and an Operation Name (optionally!)
