### PR TITLE
replace GraphQL Playground with GraphiQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ sbt run
 sbt ~reStart
 ``` 
 
-you can run queries interactively using [graphql-playground](https://github.com/prisma/graphql-playground) by opening [http://localhost:8080](http://localhost:8080) in a browser or query the `/graphql` endpoint directly. The HTTP endpoint follows [GraphQL best practices for handling the HTTP requests](http://graphql.org/learn/serving-over-http/#http-methods-headers-and-body).
+you can run queries interactively using [GraphiQL](https://github.com/graphql/graphiql/tree/main/packages/graphiql#readme)
+by opening [http://localhost:8080](http://localhost:8080) in a browser or query the `/graphql` endpoint directly.
+The HTTP endpoint follows [GraphQL best practices for handling the HTTP requests](http://graphql.org/learn/serving-over-http/#http-methods-headers-and-body).
 
 Here are some examples of the queries you can make:
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ scalacOptions ++= Seq("-deprecation", "-feature", "-Xsource:3")
 
 val akkaVersion = "2.6.15"
 val circeVersion = "0.14.1"
+val reactVersion = "17.0.2"
 val sangriaAkkaHttpVersion = "0.0.2"
 
 libraryDependencies ++= Seq(
@@ -21,15 +22,22 @@ libraryDependencies ++= Seq(
   "org.sangria-graphql" %% "sangria-akka-http-core" % sangriaAkkaHttpVersion,
   "org.sangria-graphql" %% "sangria-akka-http-circe" % sangriaAkkaHttpVersion,
 
-  "com.typesafe.akka" %% "akka-http" % "10.2.4",
+  "com.typesafe.akka" %% "akka-http" % "10.2.6",
   "com.typesafe.akka" %% "akka-actor" % akkaVersion,
   "com.typesafe.akka" %% "akka-stream" % akkaVersion,
-  "de.heikoseeberger" %% "akka-http-circe" % "1.36.0",
+  "de.heikoseeberger" %% "akka-http-circe" % "1.37.0",
 
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
   "io.circe" %% "circe-optics" % circeVersion,
-  
+
+  // GraphiQL
+  "org.webjars" % "webjars-locator-core" % "0.47",
+  // Newer versions of GraphiQL depend on org.webjars.npm:n1ru4l__push-pull-async-iterable-iterator:[2.1.4,3), which aren't webjars yet.
+  "org.webjars.npm" % "graphiql" % "1.3.2",
+  "org.webjars.npm" % "react"     % reactVersion,
+  "org.webjars.npm" % "react-dom" % reactVersion,
+
   "org.scalatest" %% "scalatest" % "3.2.9" % Test
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.4
+sbt.version=1.5.5

--- a/src/main/resources/assets/graphiql.html
+++ b/src/main/resources/assets/graphiql.html
@@ -1,0 +1,43 @@
+<!-- Based on https://github.com/graphql/graphiql/blob/8ac05f8b141b6f5cb4449c62ad67a34115490ac8/examples/graphiql-cdn/index.html -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>GraphiQL</title>
+    <style>
+      body {
+        height: 100%; width: 100%;
+        margin: 0;
+        overflow: hidden;
+      }
+      #graphiql { height: 100vh; }
+    </style>
+    <script src="umd/react.production.min.js"></script>
+    <script src="umd/react-dom.production.min.js"></script>
+    <link href="graphiql.min.css" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="graphiql">Loading...</div>
+    <script src="graphiql.min.js"></script>
+    <script>
+      function graphQLFetcher(graphQLParams) {
+        return fetch('graphql', {
+          method: 'post',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(graphQLParams),
+          credentials: 'omit',
+        }).then(response => response.json().catch(() => response.text()));
+      }
+
+      ReactDOM.render(
+        React.createElement(GraphiQL, {
+          fetcher: graphQLFetcher,
+          defaultVariableEditorOpen: true,
+        }),
+        document.getElementById('graphiql'),
+      );
+    </script>
+  </body>
+</html>

--- a/src/main/scala/Server.scala
+++ b/src/main/scala/Server.scala
@@ -1,25 +1,52 @@
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 import sangria.execution.deferred.DeferredResolver
 import sangria.execution.{ErrorWithResolver, Executor, QueryAnalysisError}
 import sangria.slowlog.SlowLog
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.StatusCodes._
-import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server._
-import sangria.marshalling.circe._
+import akka.http.scaladsl.model.MediaTypes.*
+import akka.http.scaladsl.model.StatusCodes.*
+import akka.http.scaladsl.server.Directives.*
+import akka.http.scaladsl.server.*
+import org.webjars.WebJarAssetLocator
+import sangria.http.akka.Util.explicitlyAccepts
+import sangria.marshalling.circe.*
 
-// This is the trait that makes `graphQLPlayground and prepareGraphQLRequest` available
+// This is the trait that makes `prepareGraphQLRequest` available
 import sangria.http.akka.circe.CirceHttpSupport
 
 object Server extends App with CorsSupport with CirceHttpSupport {
   implicit val system: ActorSystem = ActorSystem("sangria-server")
   import system.dispatcher
 
+  /** Tool for locating WebJar resources in the classpath. */
+  private[this] val webJarAssetLocator = new WebJarAssetLocator()
+
+  /** Route for WebJar assets.
+    *
+    * Tries to resolve the unmatched path with WebJar resources that are on the classpath.
+    * Completes if so, rejects if it fails to find a unique asset with the path name.
+    */
+  private[this] val webJars: Route = extractUnmatchedPath { path =>
+    Try(webJarAssetLocator.getFullPath(path.toString)) match {
+      case Success(fullPath) => getFromResource(fullPath)
+      case Failure(_: IllegalArgumentException) => reject
+      case Failure(e) => failWith(e)
+    }
+  }
+
+  /** Route for our GraphiQL page. */
+  private[this] val graphiql: Route =  get {
+    explicitlyAccepts(`text/html`) {
+      // This asset needs to be provided in the classpath; it's not in any WebJar.
+      getFromResource("assets/graphiql.html")
+    }
+  }
+
   val route: Route =
     optionalHeaderValueByName("X-Apollo-Tracing") { tracing =>
       path("graphql") {
-        graphQLPlayground ~
+        graphiql ~
         prepareGraphQLRequest {
           case Success(req) =>
             val middleware = if (tracing.isDefined) SlowLog.apolloTracing :: Nil else Nil
@@ -44,7 +71,8 @@ object Server extends App with CorsSupport with CirceHttpSupport {
     } ~
     (get & pathEndOrSingleSlash) {
       redirect("/graphql", PermanentRedirect)
-    }
+    } ~
+    webJars
 
   val PORT = sys.props.get("http.port").fold(8080)(_.toInt)
   val INTERFACE = "0.0.0.0"


### PR DESCRIPTION
Also updates some library versions.

Follow-up to [Gitter](https://gitter.im/sangria-graphql/sangria?at=61157e637555e333510a2122).